### PR TITLE
Fix Google Play rejection: foreground service type and edge-to-edge APIs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -67,11 +67,7 @@ flutter {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5") // ✅ syntaxe Kotlin DSL
-    implementation("androidx.core:core-ktx:1.16.0")
-}
-
-dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.work:work-runtime-ktx:2.10.1")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,12 +44,8 @@
         <service
             android:name="id.flutter.flutter_background_service.BackgroundService"
             android:exported="false"
-            android:foregroundServiceType="specialUse"
-            tools:replace="android:exported">
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="monitoring" />
-        </service>
+            android:foregroundServiceType="connectedDevice"
+            tools:replace="android:exported" />
 
         <meta-data
             android:name="flutterEmbedding"
@@ -68,7 +64,8 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
     <!-- Permissions Bluetooth traditionnelles -->
     <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/android/app/src/main/kotlin/com/lixee/assist/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/lixee/assist/MainActivity.kt
@@ -1,33 +1,15 @@
 package com.lixee.assist
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.os.Bundle
 import android.provider.Settings
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
-import androidx.core.view.WindowCompat
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     private val WIFI_BINDER_CHANNEL = "wifi_force_binder"
-    private val APP_CHANNEL = "app.channel.shared.data"  // ✅ NOUVEAU: Channel pour les paramètres
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            // ⚠️ Désactiver les API obsolètes de couleurs
-            window.statusBarColor = android.graphics.Color.TRANSPARENT
-            window.navigationBarColor = android.graphics.Color.TRANSPARENT
-        }
-
-        // ✅ Active l'affichage bord à bord
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-    }
+    private val APP_CHANNEL = "app.channel.shared.data"
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -160,11 +160,10 @@ Future<void> initializeService() async {
   final service = FlutterBackgroundService();
 
   const AndroidNotificationChannel channel = AndroidNotificationChannel(
-    notificationChannelId, // id
-    'LiXee Foreground Service', // title
-    description:
-    'Used for alert notifications.', // description
-    importance: Importance.low, // importance must be at low or higher level
+    notificationChannelId,
+    'Surveillance LiXee',
+    description: 'Surveillance des appareils LiXee connectés sur le réseau local',
+    importance: Importance.low,
   );
 
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
@@ -180,13 +179,11 @@ Future<void> initializeService() async {
       onStart: onStart,
       isForegroundMode: true,
       notificationChannelId: notificationChannelId,
-      foregroundServiceTypes: [AndroidForegroundType.specialUse],
-      foregroundServiceNotificationId:notificationId,
+      foregroundServiceTypes: [AndroidForegroundType.connectedDevice],
+      foregroundServiceNotificationId: notificationId,
       initialNotificationTitle: 'LiXee-Assist',
-      initialNotificationContent: 'Service de notifications activé ...',
-
+      initialNotificationContent: 'Surveillance des appareils LiXee en cours...',
       autoStart: true,
-
     ),
     iosConfiguration: IosConfiguration(
       /*autoStart: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   bluez:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.3"
   cli_util:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -841,10 +841,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -905,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.13.0"
   win32_registry:
     dependency: transitive
     description:
@@ -942,5 +942,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+17
+version: 1.1.0+29
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
- Change foregroundServiceType from specialUse to connectedDevice
- Replace FOREGROUND_SERVICE_SPECIAL_USE with FOREGROUND_SERVICE_CONNECTED_DEVICE
- Add CHANGE_NETWORK_STATE permission (qualifying for connectedDevice)
- Remove obsolete edge-to-edge APIs (setStatusBarColor, setNavigationBarColor)
- Remove unnecessary onCreate override in MainActivity
- Improve foreground notification text for Play Store compliance
- Clean up duplicate dependencies block in build.gradle.kts
- Bump version to 1.1.0+29