### PR TITLE
Fix WorkManager compatibility and improve polling lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📱 LiXee-Assist
 
-**LiXee-Assist** est une application mobile Android développée en Flutter permettant de détecter, configurer et gérer des appareils **LiXeeGW** via le WiFi. Elle propose un provisioning intelligent, une interface intuitive, et un support de résolution mDNS pour accéder aux interfaces embarquées.
+**LiXee-Assist** est une application mobile (Android / iOS) développée en Flutter permettant de détecter, configurer et gérer des appareils **LiXeeGW** via BLE et WiFi. Elle propose un provisioning intelligent, une interface intuitive, un proxy WebView intégré pour accéder aux interfaces embarquées (HTTP/HTTPS avec authentification), et un système de notifications en arrière-plan.
 
 ---
 
@@ -14,13 +14,16 @@
 
 ## ⚙️ Fonctionnalités
 
+- 🔵 **Provisioning BLE** : configuration WiFi des modules LiXee via Bluetooth Low Energy
 - 🔍 **Scan automatique des modules LiXee (SSID: LIXEEGW-xxxx)**
 - 📶 **Connexion WiFi automatique avec mot de passe pré-rempli**
-- 🌐 **Envoi de la configuration WiFi à l’appareil**
+- 🌐 **Envoi de la configuration WiFi à l'appareil**
 - 💾 **Sauvegarde des modules configurés (nom + URL)**
-- 🖥 **Accès WebView à l’interface des modules**
-- 🌍 **Support de la résolution mDNS** (pour les noms `*.local`)
-- 🛠 **Ajout manuel d’un appareil (nom + IP ou URL)**
+- 🖥 **Proxy WebView intégré** : accès aux interfaces des modules avec support HTTP, HTTPS et authentification Basic
+- 🌍 **Résolution mDNS** (pour les noms `*.local`)
+- 🔔 **Notifications** : surveillance périodique des appareils en arrière-plan via WorkManager
+- 🛠 **Ajout manuel d'un appareil (nom + IP ou URL)**
+- 📺 **Support Android TV**
 - 🧼 **Interface épurée, flat design, logo officiel LiXee intégré**
 
 ---
@@ -28,24 +31,25 @@
 ## 🏗 Technologies
 
 - Flutter (Dart)
-- Plugins :
-    - [`wifi_iot`](https://pub.dev/packages/wifi_iot)
-    - [`webview_flutter`](https://pub.dev/packages/webview_flutter)
-    - [`shared_preferences`](https://pub.dev/packages/shared_preferences)
-    - [`multicast_dns`](https://pub.dev/packages/multicast_dns)
+- Plugins principaux :
+    - [`flutter_blue_plus`](https://pub.dev/packages/flutter_blue_plus) - Communication BLE
+    - [`wifi_iot`](https://pub.dev/packages/wifi_iot) - Gestion WiFi
+    - [`flutter_inappwebview`](https://pub.dev/packages/flutter_inappwebview) - WebView avancée
+    - [`workmanager`](https://pub.dev/packages/workmanager) - Taches en arriere-plan (polling)
+    - [`flutter_local_notifications`](https://pub.dev/packages/flutter_local_notifications) - Notifications
+    - [`multicast_dns`](https://pub.dev/packages/multicast_dns) - Resolution mDNS
+    - [`shared_preferences`](https://pub.dev/packages/shared_preferences) - Stockage local
+    - [`dio`](https://pub.dev/packages/dio) - Client HTTP
 
 ---
 
-## 🧪 Roadmap
-- Version iOS (selon compatibilité)
+## 🚀 Installation & Deploiement
 
-## 🚀 Installation & Déploiement
+### 💻 Pre-requis
 
-### 💻 Pré-requis
-
-- Flutter SDK (v3.7+ recommandé)
-- Android Studio
-- Android 8.0+
+- Flutter SDK (v3.7.2+)
+- Android Studio / Xcode
+- Android 5.0+ / iOS 13+
 
 ### 🔧 Installation locale
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -100,7 +100,18 @@ Future<void> checkDeviceStatusBackground() async {
     String? login = parts.length == 5 ? parts[3] : null;
     String? password = parts.length == 5 ? parts[4] : null;
 
-    if (!isIPAddress(deviceUrl)) {
+    if (isIPAddress(deviceUrl)) {
+      // IP directe : normaliser l'URL
+      if (!deviceUrl.startsWith('http')) {
+        deviceUrl = "http://$deviceUrl";
+      }
+    } else if (isDNSName(deviceUrl)) {
+      // DNS classique (ex: xxx.lixee-box.fr) : utiliser tel quel
+      if (!deviceUrl.startsWith('http')) {
+        deviceUrl = "http://$deviceUrl";
+      }
+    } else {
+      // mDNS (.local) : résolution nécessaire
       String? ip = await resolveMdnsIP(deviceName);
       if (ip != null) {
         deviceUrl = "http://$ip";

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -889,10 +889,10 @@ packages:
     dependency: "direct main"
     description:
       name: workmanager
-      sha256: ed13530cccd28c5c9959ad42d657cd0666274ca74c56dea0ca183ddd527d3a00
+      sha256: "746a50c535af15b6dc225abbd9b52ab272bcd292c535a104c54b5bc02609c38a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.7.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   permission_handler: ^12.0.0+1
   change_app_package_name: ^1.5.0
   package_info_plus: ^8.3.0
-  workmanager: ^0.5.2
+  workmanager: ^0.7.0
   flutter_inappwebview: ^6.0.0
   wifi_scan: ^0.4.1
 


### PR DESCRIPTION
- Upgrade workmanager to 0.7.0 (fix build with Flutter 3.29)
- Fix background polling: handle DNS hostnames, not just IPs and mDNS
- Stop polling timer when app goes to background (avoid false red status)
- Resume polling when app returns to foreground
- Update README with current features and dependencies