### PR TITLE
Add dual auth proxy (session+Basic) and Android TV remote support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,10 +11,26 @@ import 'dart:io';
 import 'dart:convert';
 import 'screens/wifi_provision_screen.dart';
 import 'screens/home_screen.dart';
+import 'services/session_manager.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
 const String deviceCheckTaskName = 'com.lixee.assist.deviceCheck';
+
+/// Détection TV unifiée (singleton) — initialisé une seule fois dans main().
+class TVDetector {
+  static bool _isTV = false;
+  static bool get isTV => _isTV;
+
+  static Future<void> init() async {
+    if (Platform.isAndroid) {
+      try {
+        final info = await DeviceInfoPlugin().androidInfo;
+        _isTV = info.systemFeatures.contains('android.software.leanback');
+      } catch (_) {}
+    }
+  }
+}
 
 @pragma('vm:entry-point')
 void callbackDispatcher() {
@@ -70,6 +86,9 @@ void main() async {
   // Demande les permissions réseau et localisation
   await Permission.location.request();
 
+  // Détecter si l'appareil est une Android TV (une seule fois)
+  await TVDetector.init();
+
   runApp(MyApp());
 }
 
@@ -119,28 +138,73 @@ Future<void> checkDeviceStatusBackground() async {
         continue;
       }
     }
-    final Dio dio = Dio();
     try {
-      final response = await dio.get(
-        "$deviceUrl/poll",
-        options: Options(
-          sendTimeout: const Duration(seconds: 2),
-          receiveTimeout: const Duration(seconds: 5),
-          responseType: ResponseType.plain,
-          headers: (login != null && password != null)
-              ? {
-            'Authorization': 'Basic ${base64Encode(
-                utf8.encode('$login:$password'))}',
-          }
-              : null,
-        ),
-      );
+      int statusCode;
+      String responseBody;
 
-      if (response.statusCode == 200) {
+      if (login != null && password != null) {
+        // Détecter le mode auth
+        final authMode = await detectAuthMode(deviceUrl);
+
+        if (authMode == AuthMode.form) {
+          // Mode formulaire : utiliser SessionManager
+          final session = SessionManager(
+            targetBaseUrl: deviceUrl,
+            username: login,
+            password: password,
+          );
+          try {
+            final result = await session.authenticatedGet('/poll');
+            statusCode = result.statusCode;
+            responseBody = result.body;
+          } finally {
+            session.close();
+          }
+        } else {
+          // Mode Basic Auth classique
+          final dio = Dio();
+          try {
+            final response = await dio.get(
+              "$deviceUrl/poll",
+              options: Options(
+                sendTimeout: const Duration(seconds: 2),
+                receiveTimeout: const Duration(seconds: 5),
+                responseType: ResponseType.plain,
+                headers: {
+                  'Authorization': 'Basic ${base64Encode(utf8.encode('$login:$password'))}',
+                },
+              ),
+            );
+            statusCode = response.statusCode ?? 0;
+            responseBody = response.data?.toString() ?? '';
+          } finally {
+            dio.close(force: true);
+          }
+        }
+      } else {
+        // Pas d'auth
+        final dio = Dio();
+        try {
+          final response = await dio.get(
+            "$deviceUrl/poll",
+            options: Options(
+              sendTimeout: const Duration(seconds: 2),
+              receiveTimeout: const Duration(seconds: 5),
+              responseType: ResponseType.plain,
+            ),
+          );
+          statusCode = response.statusCode ?? 0;
+          responseBody = response.data?.toString() ?? '';
+        } finally {
+          dio.close(force: true);
+        }
+      }
+
+      if (statusCode == 200 && responseBody.isNotEmpty) {
         int notifId = 0;
-        if (response.data != "") {
-          List<dynamic> notifications = jsonDecode(
-              response.data)['notifications'];
+        final jsonData = jsonDecode(responseBody);
+        if (jsonData != null && jsonData['notifications'] != null) {
+          List<dynamic> notifications = jsonData['notifications'];
 
           for (var notif in notifications) {
             var title = "";
@@ -175,8 +239,6 @@ Future<void> checkDeviceStatusBackground() async {
       }
     } catch (e) {
       // Silently handle errors
-    } finally {
-      dio.close(force: true);
     }
   }
 }
@@ -187,13 +249,59 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const lixeeBlue = Color(0xFF1B75BC);
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'LiXee-Assist',
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        focusColor: lixeeBlue.withOpacity(0.2),
+        hoverColor: lixeeBlue.withOpacity(0.1),
+        // Style de focus global pour les boutons (visible au D-pad TV)
+        iconButtonTheme: IconButtonThemeData(
+          style: ButtonStyle(
+            overlayColor: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.focused)) {
+                return lixeeBlue.withOpacity(0.25);
+              }
+              return null;
+            }),
+            side: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.focused)) {
+                return const BorderSide(color: lixeeBlue, width: 2);
+              }
+              return null;
+            }),
+          ),
+        ),
+        textButtonTheme: TextButtonThemeData(
+          style: ButtonStyle(
+            overlayColor: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.focused)) {
+                return lixeeBlue.withOpacity(0.15);
+              }
+              return null;
+            }),
+          ),
+        ),
+        outlinedButtonTheme: OutlinedButtonThemeData(
+          style: ButtonStyle(
+            overlayColor: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.focused)) {
+                return lixeeBlue.withOpacity(0.15);
+              }
+              return null;
+            }),
+            side: WidgetStateProperty.resolveWith((states) {
+              if (states.contains(WidgetState.focused)) {
+                return const BorderSide(color: lixeeBlue, width: 2);
+              }
+              return const BorderSide(color: lixeeBlue);
+            }),
+          ),
+        ),
       ),
-      home: HomeScreen(), // Assure-toi que HomeScreen est bien défini
+      home: HomeScreen(),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'dart:convert'; // ✅ permet d'utiliser base64Encode et utf8
 import 'package:dio/dio.dart';
 import 'about_screen.dart';
+import '../services/session_manager.dart';
+import '../main.dart' show TVDetector;
 
 // ✅ Instance globale des notifications - référence celle du main.dart
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
@@ -532,6 +534,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   List<String> devices = [];
   Timer? _refreshTimer;
   Map<String, bool> deviceStatuses = {};
+  Map<String, SessionManager> _sessionManagers = {};
+  Map<String, AuthMode> _authModes = {};
   bool _initialized = false;
 
   @override
@@ -572,6 +576,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _refreshTimer?.cancel();
+    for (final sm in _sessionManagers.values) {
+      sm.close();
+    }
     super.dispose();
   }
 
@@ -611,40 +618,94 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     }
 
     // Requête de polling
-    final Dio dio = Dio();
     try {
-      final response = await dio.get(
-        "$finalUrl/poll",
-        options: Options(
-          sendTimeout: const Duration(seconds: 2),
-          receiveTimeout: const Duration(seconds: 5),
-          responseType: ResponseType.plain,
-          validateStatus: (status) {
-            // Accepter 200 (OK) et 401 (Unauthorized) comme des réponses valides
-            return status == 200 || status == 401;
-          },
-          headers: (login != null && password != null)
-              ? {
-            'Authorization': 'Basic ${base64Encode(utf8.encode('$login:$password'))}',
+      int statusCode;
+      String responseBody;
+
+      if (login != null && password != null) {
+        // Détecter le mode auth (cache le résultat)
+        final deviceKey = '$deviceName|$finalUrl';
+        _authModes[deviceKey] ??= await detectAuthMode(finalUrl);
+        final authMode = _authModes[deviceKey]!;
+
+        if (authMode == AuthMode.form) {
+          // Mode formulaire : utiliser SessionManager
+          _sessionManagers[deviceKey] ??= SessionManager(
+            targetBaseUrl: finalUrl,
+            username: login,
+            password: password,
+          );
+          final sm = _sessionManagers[deviceKey]!;
+          // Tester le login si pas encore de cookie
+          if (sm.sessionCookie == null) {
+            final loginOk = await sm.login();
+            if (!loginOk) {
+              // Form login échoué → fallback vers Basic Auth
+              print('[HOME] Form login failed for $deviceName, fallback to Basic Auth');
+              sm.close();
+              _sessionManagers.remove(deviceKey);
+              _authModes[deviceKey] = AuthMode.basic;
+            }
           }
-              : null,
-        ),
-      );
+        }
 
-      if ((response.statusCode == 200) ||(response.statusCode == 401)) {
-        print("✅ $deviceName est actif et authentifié via $finalUrl");
-
-        // Traitement des notifications (votre code existant)
-        if (response.data != null && response.data.toString().trim().isNotEmpty) {
+        if (_authModes[deviceKey] == AuthMode.form) {
+          final result = await _sessionManagers[deviceKey]!.authenticatedGet('/poll');
+          statusCode = result.statusCode;
+          responseBody = result.body;
+        } else {
+          // Mode Basic Auth classique
+          final dio = Dio();
           try {
-            final jsonData = jsonDecode(response.data);
+            final response = await dio.get(
+              "$finalUrl/poll",
+              options: Options(
+                sendTimeout: const Duration(seconds: 2),
+                receiveTimeout: const Duration(seconds: 5),
+                responseType: ResponseType.plain,
+                validateStatus: (status) => status == 200 || status == 401,
+                headers: {
+                  'Authorization': 'Basic ${base64Encode(utf8.encode('$login:$password'))}',
+                },
+              ),
+            );
+            statusCode = response.statusCode ?? 0;
+            responseBody = response.data?.toString() ?? '';
+          } finally {
+            dio.close(force: true);
+          }
+        }
+      } else {
+        // Pas d'auth
+        final dio = Dio();
+        try {
+          final response = await dio.get(
+            "$finalUrl/poll",
+            options: Options(
+              sendTimeout: const Duration(seconds: 2),
+              receiveTimeout: const Duration(seconds: 5),
+              responseType: ResponseType.plain,
+              validateStatus: (status) => status == 200 || status == 401,
+            ),
+          );
+          statusCode = response.statusCode ?? 0;
+          responseBody = response.data?.toString() ?? '';
+        } finally {
+          dio.close(force: true);
+        }
+      }
+
+      if (statusCode == 200 || statusCode == 401) {
+        // Traitement des notifications
+        if (responseBody.trim().isNotEmpty) {
+          try {
+            final jsonData = jsonDecode(responseBody);
 
             if (jsonData != null && jsonData['notifications'] != null) {
               List<dynamic> notifications = jsonData['notifications'];
 
               for (int i = 0; i < notifications.length; i++) {
                 var notif = notifications[i];
-                print("📋 Notification reçue: $notif");
 
                 if (notif != null && notif['title'] != null && notif['timeStamp'] != null) {
                   var title = "";
@@ -687,17 +748,12 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                           ),
                         ),
                       );
-                      print("✅ Notification affichée: $title");
-                    } catch (notifError) {
-                      print("❌ Erreur lors de l'affichage de la notification: $notifError");
-                    }
+                    } catch (_) {}
                   }
                 }
               }
             }
-          } catch (jsonError) {
-            print("❌ Erreur lors du parsing JSON: $jsonError");
-          }
+          } catch (_) {}
         }
 
         if (mounted) {
@@ -705,9 +761,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             deviceStatuses[entryKey] = true;
           });
         }
-
       } else {
-        print("❌ $deviceName a répondu avec le code ${response.statusCode}");
         if (mounted) {
           setState(() {
             deviceStatuses[entryKey] = false;
@@ -715,24 +769,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         }
       }
     } catch (e) {
-      // Gérer spécifiquement les erreurs DioException pour 401
-      if (e is DioException && e.response?.statusCode == 401) {
-        print("🔐 $deviceName est actif mais nécessite une authentification (exception 401)");
-        if (mounted) {
-          setState(() {
-            deviceStatuses[entryKey] = true; // Actif car il répond
-          });
-        }
-      } else {
-        print("❌ Erreur lors de la vérification de $deviceName : $e");
-        if (mounted) {
-          setState(() {
-            deviceStatuses[entryKey] = false;
-          });
-        }
+      if (mounted) {
+        setState(() {
+          deviceStatuses[entryKey] = false;
+        });
       }
-    } finally {
-      dio.close(force: true);
     }
   }
 
@@ -854,47 +895,50 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   Expanded(child: Text("Modifier $name")),
                 ],
               ),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: nameController,
-                    decoration: InputDecoration(labelText: "Nom"),
-                  ),
-                  TextField(
-                    controller: urlController,
-                    decoration: InputDecoration(labelText: "URL"),
-                  ),
-                  CheckboxListTile(
-                    value: useAuth,
-                    title: Text("Utiliser l'authentification"),
-                    controlAffinity: ListTileControlAffinity.leading,
-                    onChanged: (val) {
-                      setState(() => useAuth = val ?? false);
-                    },
-                  ),
-                  if (useAuth) ...[
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
                     TextField(
-                      controller: loginController,
-                      decoration: InputDecoration(labelText: "Login"),
+                      controller: nameController,
+                      decoration: InputDecoration(labelText: "Nom"),
+                      autofocus: true,
                     ),
                     TextField(
-                      controller: passwordController,
-                      obscureText: obscurePassword,
-                      decoration: InputDecoration(
-                        labelText: "Mot de passe",
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            obscurePassword ? Icons.visibility_off : Icons.visibility,
+                      controller: urlController,
+                      decoration: InputDecoration(labelText: "URL"),
+                    ),
+                    CheckboxListTile(
+                      value: useAuth,
+                      title: Text("Utiliser l'authentification"),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      onChanged: (val) {
+                        setState(() => useAuth = val ?? false);
+                      },
+                    ),
+                    if (useAuth) ...[
+                      TextField(
+                        controller: loginController,
+                        decoration: InputDecoration(labelText: "Login"),
+                      ),
+                      TextField(
+                        controller: passwordController,
+                        obscureText: obscurePassword,
+                        decoration: InputDecoration(
+                          labelText: "Mot de passe",
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              obscurePassword ? Icons.visibility_off : Icons.visibility,
+                            ),
+                            onPressed: () {
+                              setState(() => obscurePassword = !obscurePassword);
+                            },
                           ),
-                          onPressed: () {
-                            setState(() => obscurePassword = !obscurePassword);
-                          },
                         ),
                       ),
-                    ),
+                    ],
                   ],
-                ],
+                ),
               ),
               actions: [
                 OutlinedButton.icon(
@@ -1059,6 +1103,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             TextField(
               decoration: InputDecoration(labelText: "Nom de l'appareil"),
               onChanged: (value) => name = value,
+              autofocus: true,
             ),
             TextField(
               decoration: InputDecoration(labelText: "URL de l'appareil"),
@@ -1269,6 +1314,132 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     );
   }
 
+  /// Bouton AppBar focusable au D-pad, avec fond bleu LiXee.
+  Widget _buildAppBarButton({
+    required IconData icon,
+    required String tooltip,
+    required VoidCallback onPressed,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+      child: Material(
+        color: const Color(0xFF1B75BC),
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(8),
+          focusColor: Colors.white.withOpacity(0.3),
+          child: Semantics(
+            button: true,
+            label: tooltip,
+            child: Tooltip(
+              message: tooltip,
+              child: Container(
+                padding: EdgeInsets.all(TVDetector.isTV ? 16 : 12),
+                child: Icon(icon, color: Colors.white,
+                    size: TVDetector.isTV ? 28 : 20),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Dialog de confirmation de suppression d'un device.
+  void _showDeleteConfirmDialog(String entry) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Row(
+            children: [
+              Image.asset("assets/logo_x.png", height: 32),
+              SizedBox(width: 8),
+              Expanded(child: Text("Supprimer l'appareil ?")),
+            ],
+          ),
+          content: Text("Êtes-vous sûr de vouloir supprimer cet appareil ?"),
+          actions: [
+            OutlinedButton.icon(
+              icon: Icon(Icons.cancel),
+              label: Text("Annuler"),
+              onPressed: () => Navigator.of(context).pop(),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Color(0xFF1B75BC),
+                side: BorderSide(color: Color(0xFF1B75BC)),
+              ),
+            ),
+            OutlinedButton.icon(
+              icon: Icon(Icons.check),
+              label: Text("Valider"),
+              onPressed: () {
+                Navigator.of(context).pop();
+                _removeDevice(entry);
+              },
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Color(0xFF1B75BC),
+                side: BorderSide(color: Color(0xFF1B75BC)),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// Menu contextuel long-press pour les actions device sur TV.
+  void _showDeviceActionsMenu(BuildContext context, String entry, Offset position) {
+    final parts = entry.split('|');
+    final name = parts.isNotEmpty ? parts[0] : '';
+
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx, position.dy, position.dx + 1, position.dy + 1,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'notifications',
+          child: Row(children: [
+            Icon(Icons.notifications_outlined, color: Color(0xFF1B75BC)),
+            SizedBox(width: 12),
+            Text('Notifications'),
+          ]),
+        ),
+        PopupMenuItem(
+          value: 'edit',
+          child: Row(children: [
+            Icon(Icons.edit_outlined, color: Color(0xFF1B75BC)),
+            SizedBox(width: 12),
+            Text('Modifier'),
+          ]),
+        ),
+        PopupMenuItem(
+          value: 'delete',
+          child: Row(children: [
+            Icon(Icons.delete_outlined, color: Colors.red),
+            SizedBox(width: 12),
+            Text('Supprimer', style: TextStyle(color: Colors.red)),
+          ]),
+        ),
+      ],
+    ).then((value) {
+      if (value == null) return;
+      switch (value) {
+        case 'notifications':
+          _showNotificationsDialog(entry);
+          break;
+        case 'edit':
+          _showEditDialog(entry);
+          break;
+        case 'delete':
+          _showDeleteConfirmDialog(entry);
+          break;
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -1285,35 +1456,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               ],
             ),
             actions: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-                child: Material(
-                  color: Color(0xFF1B75BC),
-                  borderRadius: BorderRadius.circular(8),
-                  child: InkWell(
-                    onTap: _startProvisioning,
-                    borderRadius: BorderRadius.circular(8),
-                    child: Container(
-                      padding: EdgeInsets.all(12),
-                      child: Icon(Icons.bluetooth, color: Colors.white, size: 20),
-                    ),
-                  ),
-                ),
+              _buildAppBarButton(
+                icon: Icons.bluetooth,
+                tooltip: "Appairer un appareil",
+                onPressed: _startProvisioning,
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-                child: Material(
-                  color: Color(0xFF1B75BC),
-                  borderRadius: BorderRadius.circular(8),
-                  child: InkWell(
-                    onTap: _showManualAddDialog,
-                    borderRadius: BorderRadius.circular(8),
-                    child: Container(
-                      padding: EdgeInsets.all(12),
-                      child: Icon(Icons.note_add_outlined, color: Colors.white, size: 20),
-                    ),
-                  ),
-                ),
+              _buildAppBarButton(
+                icon: Icons.note_add_outlined,
+                tooltip: "Ajouter manuellement",
+                onPressed: _showManualAddDialog,
               ),
               PopupMenuButton<String>(
                 icon: Icon(Icons.more_vert, color: Color(0xFF1B75BC)),
@@ -1354,7 +1505,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               ? Center(child: Text("Aucun appareil enregistré.",
               style: TextStyle(color: Colors.grey)))
               : ListView.builder(
-              padding: EdgeInsets.all(isTV(context) ? 32 : 16),
+              padding: EdgeInsets.all(TVDetector.isTV ? 32 : 16),
               itemCount: devices.length,
               itemBuilder: (context, index) {
                 List<String> parts = devices[index].split("|");
@@ -1375,126 +1526,102 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                           final bool hasFocus = Focus
                               .of(focusContext)
                               .hasFocus;
-                          return Card(
-                            elevation: hasFocus ? 8 : 2,
-                            color: Colors.white,
-                            margin: EdgeInsets.symmetric(vertical: isTV(context)
-                                ? 16
-                                : 8),
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12)),
-                            child: ListTile(
-                              contentPadding: EdgeInsets.symmetric(
-                                  horizontal: isTV(context) ? 32 : 16,
-                                  vertical: isTV(context) ? 16 : 8),
-                              title: Row(
-                                children: [
-                                  if (devices[index].contains('|auth|'))
-                                    Padding(
-                                      padding: const EdgeInsets.only(right: 4.0),
-                                      child: Icon(Icons.lock_outline, size: 16,
-                                          color: Colors.grey),
+                          return GestureDetector(
+                            onLongPressStart: TVDetector.isTV
+                                ? (details) => _showDeviceActionsMenu(
+                                    context, devices[index], details.globalPosition)
+                                : null,
+                            child: Card(
+                              elevation: hasFocus ? 8 : 2,
+                              color: Colors.white,
+                              margin: EdgeInsets.symmetric(vertical: TVDetector.isTV
+                                  ? 16
+                                  : 8),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                side: hasFocus
+                                    ? const BorderSide(color: Color(0xFF1B75BC), width: 3)
+                                    : BorderSide.none,
+                              ),
+                              child: ListTile(
+                                contentPadding: EdgeInsets.symmetric(
+                                    horizontal: TVDetector.isTV ? 32 : 16,
+                                    vertical: TVDetector.isTV ? 16 : 8),
+                                title: Row(
+                                  children: [
+                                    if (devices[index].contains('|auth|'))
+                                      Padding(
+                                        padding: const EdgeInsets.only(right: 4.0),
+                                        child: Icon(Icons.lock_outline, size: 16,
+                                            color: Colors.grey),
+                                      ),
+                                    Flexible(
+                                      child: Text(
+                                        name,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: TextStyle(fontWeight: FontWeight.w600,
+                                            fontSize: TVDetector.isTV ? 24 : 16),
+                                      ),
                                     ),
-                                  Text(
-                                    name,
-                                    style: TextStyle(fontWeight: FontWeight.w600,
-                                        fontSize: isTV(context) ? 24 : 16),
-                                  ),
-                                ],
-                              ),
-                              subtitle: Text(
-                                url,
-                                style: TextStyle(fontSize: isTV(context) ? 20 : 14),
-                              ),
-                              //leading: Icon(Icons.devices_other, color: Color(0xFF1B75BC)),
-                              leading: Icon(
-                                Icons.devices_other,
-                                color: deviceStatuses[devices[index]] == true
-                                    ? Colors
-                                    .green
-                                    : Colors.red,
-                              ),
-                              trailing: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  IconButton(
-                                    icon: Icon(
-                                        hasNotifications
-                                            ? Icons.notifications
-                                            : Icons.notifications_outlined,
-                                        color: hasNotifications ? Colors.amber : Color(0xFF1B75BC)),
-                                    tooltip: "Voir les notifications",
-                                    onPressed: () =>
-                                        _showNotificationsDialog(devices[index]),
-                                  ),
-                                  IconButton(
-                                    icon: Icon(
-                                        Icons.edit_outlined,
-                                        color: Color(0xFF1B75BC)),
-                                    tooltip: "Modifier",
-                                    onPressed: () =>
-                                        _showEditDialog(devices[index]),
-                                  ),
-                                  IconButton(
-                                    icon: Icon(Icons.delete_outlined,
-                                        color: Color(0xFF1B75BC)),
-                                    onPressed: () {
-                                      showDialog(
-                                        context: context,
-                                        builder: (BuildContext context) {
-                                          return AlertDialog(
-                                            title: Row(
-                                              children: [
-                                                Image.asset(
-                                                    "assets/logo_x.png",
-                                                    height: 32),
-                                                SizedBox(width: 8),
-                                                Expanded(child: Text(
-                                                    "Supprimer l'appareil ?")),
-                                              ],
-                                            ),
-                                            content: Text(
-                                                "Êtes-vous sûr de vouloir supprimer cet appareil ?"),
-                                            actions: [
-                                              OutlinedButton.icon(
-                                                icon: Icon(Icons.cancel,),
-                                                label: Text("Annuler"),
-                                                onPressed: () {
-                                                  Navigator.of(context).pop();
-                                                },
-                                                style: OutlinedButton.styleFrom(
-                                                  foregroundColor: Color(
-                                                      0xFF1B75BC),
-                                                  side: BorderSide(
-                                                      color: Color(0xFF1B75BC)),
-                                                ),
-                                              ),
-                                              OutlinedButton.icon(
-                                                icon: Icon(Icons.check),
-                                                label: Text("Valider"),
-                                                onPressed: () {
-                                                  Navigator
-                                                      .of(context)
-                                                      .pop(); // Fermer le dialogue
-                                                  _removeDevice(
-                                                      devices[index]); // Supprimer réellement
-                                                },
-                                                style: OutlinedButton.styleFrom(
-                                                  foregroundColor: Color(
-                                                      0xFF1B75BC),
-                                                  side: BorderSide(
-                                                      color: Color(0xFF1B75BC)),
-                                                ),
-                                              ),
-                                            ],
+                                  ],
+                                ),
+                                subtitle: Text(
+                                  url,
+                                  style: TextStyle(fontSize: TVDetector.isTV ? 20 : 14),
+                                ),
+                                leading: Icon(
+                                  Icons.devices_other,
+                                  color: deviceStatuses[devices[index]] == true
+                                      ? Colors.green
+                                      : Colors.red,
+                                  size: TVDetector.isTV ? 32 : 24,
+                                ),
+                                trailing: TVDetector.isTV
+                                    // TV : un seul bouton menu (les actions sont dans le long-press)
+                                    ? IconButton(
+                                        icon: Icon(Icons.more_vert, color: Color(0xFF1B75BC),
+                                            size: TVDetector.isTV ? 32 : 24),
+                                        tooltip: "Actions",
+                                        onPressed: () {
+                                          // Calculer la position du bouton pour le popup
+                                          final RenderBox box = focusContext.findRenderObject() as RenderBox;
+                                          final Offset pos = box.localToGlobal(
+                                            Offset(box.size.width - 48, box.size.height / 2),
                                           );
+                                          _showDeviceActionsMenu(context, devices[index], pos);
                                         },
-                                      );
-                                    },
-                                  ),
-                                ],
+                                      )
+                                    // Mobile : les 3 boutons classiques
+                                    : Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          IconButton(
+                                            icon: Icon(
+                                                hasNotifications
+                                                    ? Icons.notifications
+                                                    : Icons.notifications_outlined,
+                                                color: hasNotifications ? Colors.amber : Color(0xFF1B75BC)),
+                                            tooltip: "Voir les notifications",
+                                            onPressed: () =>
+                                                _showNotificationsDialog(devices[index]),
+                                          ),
+                                          IconButton(
+                                            icon: Icon(
+                                                Icons.edit_outlined,
+                                                color: Color(0xFF1B75BC)),
+                                            tooltip: "Modifier",
+                                            onPressed: () =>
+                                                _showEditDialog(devices[index]),
+                                          ),
+                                          IconButton(
+                                            icon: Icon(Icons.delete_outlined,
+                                                color: Color(0xFF1B75BC)),
+                                            onPressed: () => _showDeleteConfirmDialog(devices[index]),
+                                          ),
+                                        ],
+                                      ),
+                                onTap: () => _openDevice(devices[index]),
                               ),
-                              onTap: () => _openDevice(devices[index]),
                             ),
                           );
                         },

--- a/lib/screens/webview_device_screen.dart
+++ b/lib/screens/webview_device_screen.dart
@@ -2,9 +2,9 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import '../services/proxy_server.dart';
+import '../main.dart' show TVDetector;
 
 class WebViewDeviceScreen extends StatefulWidget {
   final String deviceEntry;
@@ -23,7 +23,6 @@ class WebViewDeviceScreen extends StatefulWidget {
 class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
   InAppWebViewController? _controller;
   HttpServer? _proxyServer;
-  bool isTVDevice = false;
 
   final FocusNode _focusNode = FocusNode(
     skipTraversal: true,
@@ -36,14 +35,18 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
   bool _isDisposed = false;
   int _loadingProgress = 0;
   int _proxyPort = 0;
+  DateTime? _lastProxyRestart;
 
   late String name;
   String? login;
   String? password;
 
+  // --- Curseur TV ---
   double cursorX = 200;
   double cursorY = 200;
-  final double step = 50;
+  double _currentStep = 15; // Vitesse initiale (accélère si touche maintenue)
+  DateTime? _lastKeyTime;
+  bool _showClickFeedback = false;
 
   @override
   void initState() {
@@ -55,24 +58,7 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
       login = parts[3];
       password = parts[4];
     }
-    _detectIfTV();
     _startProxyAndLoad();
-  }
-
-  void _detectIfTV() async {
-    try {
-      if (Platform.isAndroid) {
-        final info = await DeviceInfoPlugin().androidInfo;
-        final hasLeanback = info.systemFeatures.contains("android.software.leanback");
-        if (mounted) {
-          setState(() {
-            isTVDevice = hasLeanback;
-          });
-        }
-      }
-    } catch (e) {
-      print("⚠️ Impossible de déterminer si l'appareil est une TV : $e");
-    }
   }
 
   void _startProxyAndLoad() async {
@@ -120,30 +106,33 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
           builder: (context, setState) {
             return AlertDialog(
               title: Text("🔐 Authentification requise"),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text("Cette page nécessite un identifiant."),
-                  SizedBox(height: 12),
-                  TextField(
-                    decoration: InputDecoration(labelText: "Login"),
-                    onChanged: (val) => tempLogin = val,
-                  ),
-                  TextField(
-                    obscureText: obscure,
-                    onChanged: (val) => tempPassword = val,
-                    decoration: InputDecoration(
-                      labelText: "Mot de passe",
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          obscure ? Icons.visibility_off : Icons.visibility,
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text("Cette page nécessite un identifiant."),
+                    SizedBox(height: 12),
+                    TextField(
+                      decoration: InputDecoration(labelText: "Login"),
+                      onChanged: (val) => tempLogin = val,
+                      autofocus: true,
+                    ),
+                    TextField(
+                      obscureText: obscure,
+                      onChanged: (val) => tempPassword = val,
+                      decoration: InputDecoration(
+                        labelText: "Mot de passe",
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            obscure ? Icons.visibility_off : Icons.visibility,
+                          ),
+                          onPressed: () =>
+                              setState(() => obscure = !obscure),
                         ),
-                        onPressed: () =>
-                            setState(() => obscure = !obscure),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
               actions: [
                 TextButton(
@@ -196,59 +185,43 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
     }
   }
 
-  /*Future<void> _checkPageForAuth() async {
-    try {
-      final result = await _controller?.evaluateJavascript(source: "document.title");
-      final title = result?.toString().toLowerCase() ?? "";
-      print("📄 Page title: $title");
-
-      final suspicious = ["unauthorized", "forbidden", "non disponible", "not available", "login"];
-
-      if (title.isEmpty || suspicious.any((kw) => title.contains(kw))) {
-        if (!_hasTriedAuth && login == null) {
-          _hasTriedAuth = true;
-          await _askForAuthentication();
-        }
-      }
-    } catch (e) {
-      print("⚠️ JS error: $e");
-      if (!_hasTriedAuth && login == null) {
-        _hasTriedAuth = true;
-        await _askForAuthentication();
-      }
-    }
-  }*/
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: true,
-      appBar: AppBar(
-        title: Row(
-          children: [
-            Text("🔗 $name"),
-            if (login != null)
-              Padding(
-                padding: const EdgeInsets.only(left: 6.0),
-                child: Icon(Icons.lock_outline, size: 18),
+    return PopScope(
+      canPop: true,
+      child: Scaffold(
+        resizeToAvoidBottomInset: true,
+        // TV : pas d'AppBar (plein écran), le bouton Retour de la télécommande suffit
+        appBar: TVDetector.isTV
+            ? null
+            : AppBar(
+                title: Row(
+                  children: [
+                    Text("🔗 $name"),
+                    if (login != null)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 6.0),
+                        child: Icon(Icons.lock_outline, size: 18),
+                      ),
+                  ],
+                ),
+                actions: [
+                  IconButton(
+                    icon: Icon(Icons.refresh),
+                    tooltip: "Rafraîchir",
+                    onPressed: () {
+                      _controller?.reload();
+                    },
+                  ),
+                ],
               ),
-          ],
-        ),
-        actions: [
-          IconButton(
-            icon: Icon(Icons.refresh),
-            tooltip: "Rafraîchir",
-            onPressed: () {
-              _controller?.reload();
-            },
+        body: SafeArea(
+          child: SizedBox.expand(
+            child: _proxyReady
+                ? (TVDetector.isTV ? _buildTVWebView() : _buildMobileWebView())
+                : const Center(child: CircularProgressIndicator()),
           ),
-        ],
-      ),
-      body: SafeArea( // ✅ garde la zone sûre
-        child: SizedBox.expand( // ✅ prend tout l’espace restant
-          child: _proxyReady
-              ? (isTVDevice ? _buildTVWebView() : _buildMobileWebView())
-              : const Center(child: CircularProgressIndicator()),
         ),
       ),
     );
@@ -256,24 +229,64 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
 
 
 
+  /// Calcule le step avec accélération : appuis rapides = mouvement plus grand.
+  double _getAcceleratedStep() {
+    final now = DateTime.now();
+    if (_lastKeyTime != null && now.difference(_lastKeyTime!) < const Duration(milliseconds: 200)) {
+      // Touche maintenue → accélérer (max 50px)
+      _currentStep = (_currentStep + 5).clamp(15, 50);
+    } else {
+      // Nouvelle pression → reset
+      _currentStep = 15;
+    }
+    _lastKeyTime = now;
+    return _currentStep;
+  }
+
+  /// Scrolle la page web quand le curseur atteint les bords de l'écran.
+  void _scrollWebViewIfNeeded(double step, String direction) {
+    const edgeMargin = 60.0; // Zone de bord qui déclenche le scroll
+    final size = MediaQuery.of(context).size;
+    final scrollAmount = step * 2; // Scroll un peu plus que le mouvement curseur
+
+    if (direction == 'up' && cursorY <= edgeMargin) {
+      _controller?.evaluateJavascript(source: 'window.scrollBy(0, -$scrollAmount)');
+    } else if (direction == 'down' && cursorY >= size.height - edgeMargin) {
+      _controller?.evaluateJavascript(source: 'window.scrollBy(0, $scrollAmount)');
+    } else if (direction == 'left' && cursorX <= edgeMargin) {
+      _controller?.evaluateJavascript(source: 'window.scrollBy(-$scrollAmount, 0)');
+    } else if (direction == 'right' && cursorX >= size.width - edgeMargin) {
+      _controller?.evaluateJavascript(source: 'window.scrollBy($scrollAmount, 0)');
+    }
+  }
+
   Widget _buildTVWebView() {
     return KeyboardListener(
       focusNode: _focusNode,
       autofocus: true,
       onKeyEvent: (KeyEvent event) async {
-        if (event is KeyDownEvent) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
           final size = MediaQuery.of(context).size;
+          final step = _getAcceleratedStep();
           if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
             setState(() => cursorY = (cursorY - step).clamp(0, size.height));
+            _scrollWebViewIfNeeded(step, 'up');
           } else if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
             setState(() => cursorY = (cursorY + step).clamp(0, size.height));
+            _scrollWebViewIfNeeded(step, 'down');
           } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
             setState(() => cursorX = (cursorX - step).clamp(0, size.width));
+            _scrollWebViewIfNeeded(step, 'left');
           } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
             setState(() => cursorX = (cursorX + step).clamp(0, size.width));
+            _scrollWebViewIfNeeded(step, 'right');
           } else if (event.logicalKey == LogicalKeyboardKey.select ||
               event.logicalKey == LogicalKeyboardKey.enter) {
+            // Retour visuel au clic
+            setState(() => _showClickFeedback = true);
             await _simulateClickAt(cursorX, cursorY);
+            await Future.delayed(const Duration(milliseconds: 200));
+            if (mounted) setState(() => _showClickFeedback = false);
           }
         }
       },
@@ -281,16 +294,35 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
         children: [
           _buildInAppWebView(),
           if (_isLoading) _buildLoadingOverlay(),
+          // Curseur TV (plus grand, avec ombre et feedback de clic)
           Positioned(
-            left: cursorX - 8,
-            top: cursorY - 8,
-            child: Container(
-              width: 16,
-              height: 16,
-              decoration: BoxDecoration(
-                color: Colors.white.withOpacity(0.9),
-                shape: BoxShape.circle,
-                border: Border.all(color: Colors.blue, width: 2),
+            left: cursorX - 12,
+            top: cursorY - 12,
+            child: IgnorePointer(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 100),
+                width: _showClickFeedback ? 32 : 24,
+                height: _showClickFeedback ? 32 : 24,
+                transform: _showClickFeedback
+                    ? (Matrix4.identity()..translate(-4.0, -4.0))
+                    : Matrix4.identity(),
+                decoration: BoxDecoration(
+                  color: _showClickFeedback
+                      ? Colors.blue.withOpacity(0.5)
+                      : Colors.white.withOpacity(0.9),
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: _showClickFeedback ? Colors.white : const Color(0xFF1B75BC),
+                    width: 2.5,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.3),
+                      blurRadius: 6,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -357,6 +389,42 @@ class _WebViewDeviceScreenState extends State<WebViewDeviceScreen> {
       onLoadStop: (controller, url) async {
         if (mounted) {
           setState(() => _isLoading = false);
+        }
+
+        // TV : zoom à 60% pour afficher plus de contenu sur grand écran
+        if (TVDetector.isTV) {
+          await controller.evaluateJavascript(
+            source: "document.body.style.zoom = '60%';",
+          );
+        }
+
+        // Détecter si la page de login ESP32 s'affiche dans la WebView
+        final hasLoginForm = await controller.evaluateJavascript(
+          source: "document.querySelector('form[action=\"/login\"]') !== null",
+        );
+        if (hasLoginForm == true || hasLoginForm == 'true') {
+          if (login != null && password != null) {
+            // Cooldown : éviter les boucles de redémarrage du proxy (10s minimum)
+            final now = DateTime.now();
+            if (_lastProxyRestart != null && now.difference(_lastProxyRestart!) < const Duration(seconds: 10)) {
+              return;
+            }
+            _lastProxyRestart = now;
+            // Credentials déjà sauvegardés mais session expirée : relancer le proxy
+            _proxyServer?.close(force: true);
+            if (mounted) {
+              setState(() {
+                _proxyReady = false;
+                _isLoading = true;
+                _loadingProgress = 0;
+              });
+            }
+            _startProxyAndLoad();
+          } else if (!_hasTriedAuth) {
+            // Pas de credentials : afficher le dialog d'auth LiXee-Assist
+            _hasTriedAuth = true;
+            await _askForAuthentication();
+          }
         }
       },
       onReceivedHttpAuthRequest: (controller, challenge) async {

--- a/lib/services/proxy_server.dart
+++ b/lib/services/proxy_server.dart
@@ -5,106 +5,69 @@ import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
 import 'package:shelf_proxy/shelf_proxy.dart';
 
+import 'session_manager.dart';
+
 Future<HttpServer> startProxy({
   required String targetBaseUrl,
   String? username,
   String? password,
 }) async {
   final resolvedUrl = await _resolveRedirects(targetBaseUrl);
-
-  final isHttps = resolvedUrl.startsWith('https://');
   final hasAuth = username != null && password != null;
 
-  if (isHttps && hasAuth) {
-    return _startCustomProxy(resolvedUrl, username, password);
-  }
-
-  Handler handler;
   if (hasAuth) {
-    handler = const Pipeline()
-        .addMiddleware(_authMiddleware(username!, password!))
-        .addHandler(proxyHandler(resolvedUrl));
-  } else {
-    handler = proxyHandler(resolvedUrl);
+    // Détecter le mode d'auth (formulaire ou Basic Auth)
+    final authMode = await detectAuthMode(resolvedUrl);
+    print('[PROXY] resolvedUrl=$resolvedUrl, authMode=$authMode');
+
+    if (authMode == AuthMode.form) {
+      // Tester le login par formulaire avant de lancer le proxy
+      final sessionManager = SessionManager(
+        targetBaseUrl: resolvedUrl,
+        username: username!,
+        password: password!,
+      );
+      final loginOk = await sessionManager.login();
+
+      if (loginOk) {
+        // Réutiliser le même SessionManager (évite un double login sur l'ESP32)
+        return _startSessionProxy(resolvedUrl, sessionManager);
+      } else {
+        // Form login échoué → fallback Basic Auth
+        sessionManager.close();
+        print('[PROXY] Form login failed, fallback to Basic Auth');
+        return _startBasicAuthProxy(resolvedUrl, username!, password!);
+      }
+    } else {
+      return _startBasicAuthProxy(resolvedUrl, username!, password!);
+    }
   }
 
+  // Pas d'auth : proxy simple
+  final handler = proxyHandler(resolvedUrl);
   final server = await io.serve(handler, '127.0.0.1', 0);
   return server;
 }
 
-/// Proxy custom pour HTTPS avec auth — basé directement sur HttpServer
-Future<HttpServer> _startCustomProxy(String targetBaseUrl, String username, String password) async {
+/// Proxy avec authentification par formulaire + cookie de session.
+Future<HttpServer> _startSessionProxy(String targetBaseUrl, SessionManager sessionManager) async {
   final targetUri = Uri.parse(targetBaseUrl);
-  final encoded = base64Encode(utf8.encode('$username:$password'));
-  final server = await HttpServer.bind('127.0.0.1', 0);
+  print('[PROXY] Starting session proxy for $targetBaseUrl');
 
+  final server = await HttpServer.bind('127.0.0.1', 0);
   final httpClient = HttpClient();
   httpClient.badCertificateCallback = (cert, host, port) => true;
-
-  // Pré-enregistrer les credentials pour tout le host (tous les chemins)
-  final rootUri = Uri(scheme: targetUri.scheme, host: targetUri.host, port: targetUri.port, path: '/');
-  httpClient.addCredentials(
-    rootUri,
-    '',
-    HttpClientBasicCredentials(username, password),
-  );
-
-  // Callback de fallback si le serveur challenge avec un realm spécifique
-  httpClient.authenticate = (Uri url, String scheme, String? realm) async {
-    httpClient.addCredentials(
-      url,
-      realm ?? '',
-      HttpClientBasicCredentials(username, password),
-    );
-    return true;
-  };
 
   server.listen((HttpRequest clientRequest) async {
     try {
       final path = clientRequest.uri.toString();
       final url = targetUri.resolve(path);
 
-      final proxyRequest = await httpClient.openUrl(clientRequest.method, url);
+      final bodyBytes = await _proxyRequest(
+        httpClient, clientRequest, url, targetUri, sessionManager,
+      );
 
-      // Copier les headers du client (sauf host, authorization, accept-encoding)
-      clientRequest.headers.forEach((name, values) {
-        final lower = name.toLowerCase();
-        if (lower != 'host' && lower != 'authorization' && lower != 'accept-encoding') {
-          for (var value in values) {
-            proxyRequest.headers.add(name, value);
-          }
-        }
-      });
-
-      // Injecter l'auth directement (pré-emptive)
-      proxyRequest.headers.set('Authorization', 'Basic $encoded');
-      proxyRequest.headers.set('host', targetUri.host);
-      proxyRequest.followRedirects = true;
-      proxyRequest.maxRedirects = 5;
-
-      // Transférer le body de la requête
-      await for (final chunk in clientRequest) {
-        proxyRequest.add(chunk);
-      }
-
-      final proxyResponse = await proxyRequest.close();
-
-      clientRequest.response.statusCode = proxyResponse.statusCode;
-
-      // Copier les headers de réponse
-      proxyResponse.headers.forEach((name, values) {
-        final lower = name.toLowerCase();
-        if (lower != 'www-authenticate' &&
-            lower != 'transfer-encoding' &&
-            lower != 'content-encoding' &&
-            lower != 'content-length') {
-          for (var value in values) {
-            clientRequest.response.headers.add(name, value);
-          }
-        }
-      });
-
-      await proxyResponse.pipe(clientRequest.response);
+      if (bodyBytes == null) return; // déjà géré (retry ou erreur)
     } catch (e) {
       try {
         clientRequest.response.statusCode = 502;
@@ -117,7 +80,229 @@ Future<HttpServer> _startCustomProxy(String targetBaseUrl, String username, Stri
   return server;
 }
 
-/// Suit les redirections pour trouver l'URL finale
+/// Effectue une requête proxy avec gestion de session, redirections et re-login.
+/// Boucle unique : suit les redirections, détecte le login, re-auth si besoin.
+Future<List<int>?> _proxyRequest(
+  HttpClient httpClient,
+  HttpRequest clientRequest,
+  Uri url,
+  Uri targetUri,
+  SessionManager sessionManager,
+) async {
+  final clientBody = await clientRequest.fold<List<int>>(
+      [], (prev, chunk) => prev..addAll(chunk));
+  final originalUrl = url;
+  var currentUrl = url;
+  var currentMethod = clientRequest.method;
+  int loginRetries = 0;
+  int redirectCount = 0;
+  const maxLoginRetries = 2;
+  const maxRedirects = 5;
+  // Compteur total pour éviter toute boucle infinie
+  int totalIterations = 0;
+  const maxIterations = 10;
+
+  while (totalIterations < maxIterations) {
+    totalIterations++;
+    final cookie = await sessionManager.getSessionCookie();
+
+    final proxyRequest =
+        await httpClient.openUrl(currentMethod, currentUrl);
+
+    // Copier les headers (sans host, cookie, auth, encoding, referer)
+    clientRequest.headers.forEach((name, values) {
+      final lower = name.toLowerCase();
+      if (lower != 'host' &&
+          lower != 'cookie' &&
+          lower != 'authorization' &&
+          lower != 'accept-encoding' &&
+          lower != 'referer') {
+        for (var value in values) {
+          proxyRequest.headers.add(name, value);
+        }
+      }
+    });
+
+    if (cookie != null) {
+      proxyRequest.headers.set('Cookie', cookie);
+    }
+    proxyRequest.headers.set('host', targetUri.host);
+    proxyRequest.followRedirects = false;
+
+    // Body uniquement sur la toute première requête
+    if (loginRetries == 0 && redirectCount == 0) {
+      proxyRequest.add(clientBody);
+    }
+
+    final response = await proxyRequest.close();
+    final bytes = await response.fold<List<int>>(
+        [], (prev, chunk) => prev..addAll(chunk));
+    final body = utf8.decode(bytes, allowMalformed: true);
+    final location = response.headers.value('location');
+
+    // Capturer Set-Cookie (rotation/rafraîchissement par l'ESP32)
+    final setCookies = response.headers['set-cookie'];
+    if (setCookies != null && setCookies.isNotEmpty) {
+      final parts = <String>[];
+      for (final h in setCookies) {
+        final nv = h.split(';').first.trim();
+        if (nv.isNotEmpty) parts.add(nv);
+      }
+      if (parts.isNotEmpty) {
+        sessionManager.updateSessionCookie(parts.join('; '));
+      }
+    }
+
+    // --- Cas 1 : Page de login détectée → re-auth + retry depuis l'URL d'origine ---
+    if (sessionManager.isLoginPage(response.statusCode, body, location)) {
+      print('[PROXY] Login page detected: status=${response.statusCode}, location=$location, bodyLen=${body.length}');
+      if (loginRetries >= maxLoginRetries) {
+        print('[PROXY] Max login retries reached ($maxLoginRetries)');
+        break;
+      }
+      sessionManager.invalidateSession();
+      final success = await sessionManager.login();
+      if (!success) break;
+      // Repartir de l'URL d'origine
+      currentUrl = originalUrl;
+      currentMethod = clientRequest.method;
+      redirectCount = 0;
+      loginRetries++;
+      print('[PROXY] Re-auth #$loginRetries, retry ${originalUrl.path}');
+      continue;
+    }
+
+    // --- Cas 2 : Redirection normale → suivre avec le cookie ---
+    if (response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        location != null &&
+        location.isNotEmpty &&
+        redirectCount < maxRedirects) {
+      currentUrl = currentUrl.resolve(location);
+      currentMethod = 'GET';
+      redirectCount++;
+      print('[PROXY] Redirect #$redirectCount → $currentUrl');
+      continue;
+    }
+
+    // --- Cas 3 : Réponse finale → envoyer au WebView ---
+    _sendResponse(clientRequest.response, response, bytes);
+    return bytes;
+  }
+
+  // Fallback : max atteint
+  print('[PROXY] Max iterations reached for ${originalUrl.path}');
+  try {
+    clientRequest.response.statusCode = 502;
+    clientRequest.response.write('Proxy: max retries');
+    await clientRequest.response.close();
+  } catch (_) {}
+  return null;
+}
+
+/// Envoie la réponse proxy au client.
+void _sendResponse(HttpResponse clientResponse, HttpClientResponse proxyResponse, List<int> bodyBytes) async {
+  try {
+    clientResponse.statusCode = proxyResponse.statusCode;
+
+    proxyResponse.headers.forEach((name, values) {
+      final lower = name.toLowerCase();
+      // Ne pas transférer set-cookie, transfer-encoding, content-encoding, content-length
+      if (lower != 'set-cookie' &&
+          lower != 'transfer-encoding' &&
+          lower != 'content-encoding' &&
+          lower != 'content-length') {
+        for (var value in values) {
+          clientResponse.headers.add(name, value);
+        }
+      }
+    });
+
+    clientResponse.add(bodyBytes);
+    await clientResponse.close();
+  } catch (_) {}
+}
+
+/// Proxy avec Basic Auth classique (ancien firmware).
+Future<HttpServer> _startBasicAuthProxy(String targetBaseUrl, String username, String password) async {
+  final targetUri = Uri.parse(targetBaseUrl);
+  final encoded = base64Encode(utf8.encode('$username:$password'));
+  final isHttps = targetBaseUrl.startsWith('https://');
+
+  if (isHttps) {
+    // HTTPS + Basic Auth : proxy custom avec HttpClient
+    final server = await HttpServer.bind('127.0.0.1', 0);
+    final httpClient = HttpClient();
+    httpClient.badCertificateCallback = (cert, host, port) => true;
+
+    final rootUri = Uri(scheme: targetUri.scheme, host: targetUri.host, port: targetUri.port, path: '/');
+    httpClient.addCredentials(rootUri, '', HttpClientBasicCredentials(username, password));
+    httpClient.authenticate = (Uri url, String scheme, String? realm) async {
+      httpClient.addCredentials(url, realm ?? '', HttpClientBasicCredentials(username, password));
+      return true;
+    };
+
+    server.listen((HttpRequest clientRequest) async {
+      try {
+        final path = clientRequest.uri.toString();
+        final url = targetUri.resolve(path);
+
+        final proxyRequest = await httpClient.openUrl(clientRequest.method, url);
+
+        clientRequest.headers.forEach((name, values) {
+          final lower = name.toLowerCase();
+          if (lower != 'host' && lower != 'authorization' && lower != 'accept-encoding') {
+            for (var value in values) {
+              proxyRequest.headers.add(name, value);
+            }
+          }
+        });
+
+        proxyRequest.headers.set('Authorization', 'Basic $encoded');
+        proxyRequest.headers.set('host', targetUri.host);
+        proxyRequest.followRedirects = true;
+        proxyRequest.maxRedirects = 5;
+
+        await for (final chunk in clientRequest) {
+          proxyRequest.add(chunk);
+        }
+
+        final proxyResponse = await proxyRequest.close();
+        clientRequest.response.statusCode = proxyResponse.statusCode;
+
+        proxyResponse.headers.forEach((name, values) {
+          final lower = name.toLowerCase();
+          if (lower != 'www-authenticate' &&
+              lower != 'transfer-encoding' &&
+              lower != 'content-encoding' &&
+              lower != 'content-length') {
+            for (var value in values) {
+              clientRequest.response.headers.add(name, value);
+            }
+          }
+        });
+
+        await proxyResponse.pipe(clientRequest.response);
+      } catch (e) {
+        try {
+          clientRequest.response.statusCode = 502;
+          clientRequest.response.write('Proxy error: $e');
+          await clientRequest.response.close();
+        } catch (_) {}
+      }
+    });
+
+    return server;
+  } else {
+    // HTTP + Basic Auth : shelf_proxy avec middleware
+    final handler = const Pipeline()
+        .addMiddleware(_authMiddleware(username, password))
+        .addHandler(proxyHandler(targetBaseUrl));
+    return io.serve(handler, '127.0.0.1', 0);
+  }
+}
+
+/// Suit les redirections pour trouver l'URL finale.
 Future<String> _resolveRedirects(String url) async {
   try {
     final client = HttpClient();
@@ -132,9 +317,16 @@ Future<String> _resolveRedirects(String url) async {
     if (response.statusCode >= 300 && response.statusCode < 400) {
       final location = response.headers.value('location');
       if (location != null) {
-        final resolved = Uri.parse(url).resolve(location).toString();
-        client.close();
-        return resolved;
+        final resolvedUri = Uri.parse(url).resolve(location);
+        final originalUri = Uri.parse(url);
+        // Ne suivre que les redirections qui changent le scheme ou le host
+        // (ex: HTTP→HTTPS), pas les redirections d'auth (ex: / → /login)
+        if (resolvedUri.scheme != originalUri.scheme ||
+            resolvedUri.host != originalUri.host) {
+          client.close();
+          // Ne garder que scheme://host[:port], ignorer le path (souvent /login)
+          return resolvedUri.origin;
+        }
       }
     }
 

--- a/lib/services/session_manager.dart
+++ b/lib/services/session_manager.dart
@@ -1,0 +1,279 @@
+import 'dart:io';
+import 'dart:convert';
+import 'dart:async';
+
+enum AuthMode { basic, form }
+
+/// Résultat d'une requête authentifiée.
+class AuthenticatedResponse {
+  final int statusCode;
+  final String body;
+
+  AuthenticatedResponse(this.statusCode, this.body);
+}
+
+/// Vérifie si le body HTML contient un formulaire de login (guillemets simples ou doubles).
+bool _hasLoginForm(String body) {
+  return body.contains('<form') &&
+      (body.contains('action="/login"') || body.contains("action='/login'"));
+}
+
+/// Détecte le mode d'authentification d'un appareil.
+Future<AuthMode> detectAuthMode(String targetBaseUrl) async {
+  final client = HttpClient();
+  client.badCertificateCallback = (cert, host, port) => true;
+  client.connectionTimeout = const Duration(seconds: 5);
+
+  try {
+    final uri = Uri.parse(targetBaseUrl);
+    final request = await client.getUrl(uri);
+    request.headers.set('Accept', 'text/html,application/xhtml+xml,*/*');
+    request.followRedirects = false;
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+
+    print('[AUTH-DETECT] GET / → status=${response.statusCode}, bodyLen=${body.length}, body=${body.substring(0, body.length > 200 ? 200 : body.length)}');
+
+    // Cas 1 : La page d'accueil contient directement le formulaire de login
+    if (_hasLoginForm(body)) {
+      print('[AUTH-DETECT] → AuthMode.form (login form in body)');
+      return AuthMode.form;
+    }
+
+    // Cas 2 : Redirection vers /login
+    if (response.statusCode >= 300 && response.statusCode < 400) {
+      final location = response.headers.value('location') ?? '';
+      if (location.contains('/login') || location == '/') {
+        print('[AUTH-DETECT] → AuthMode.form (redirect to $location)');
+        return AuthMode.form;
+      }
+    }
+
+    // Cas 3 : 401 Unauthorized → vérifier si /login existe avec un formulaire
+    if (response.statusCode == 401) {
+      try {
+        final loginUri = uri.resolve('/login');
+        print('[AUTH-DETECT] 401 detected, trying GET $loginUri');
+        final loginReq = await client.getUrl(loginUri);
+        loginReq.headers.set('Accept', 'text/html,application/xhtml+xml,*/*');
+        loginReq.followRedirects = false;
+        final loginResp = await loginReq.close();
+        final loginBody = await loginResp.transform(utf8.decoder).join();
+        print('[AUTH-DETECT] GET /login → status=${loginResp.statusCode}, bodyLen=${loginBody.length}, body=${loginBody.substring(0, loginBody.length > 200 ? 200 : loginBody.length)}');
+        if (_hasLoginForm(loginBody)) {
+          print('[AUTH-DETECT] → AuthMode.form (login form at /login)');
+          return AuthMode.form;
+        }
+      } catch (e) {
+        print('[AUTH-DETECT] GET /login error: $e');
+      }
+    }
+
+    print('[AUTH-DETECT] → AuthMode.basic (fallback)');
+    return AuthMode.basic;
+  } catch (e) {
+    print('[AUTH-DETECT] Exception: $e');
+    return AuthMode.basic;
+  } finally {
+    client.close();
+  }
+}
+
+/// Gère l'authentification par formulaire et le cookie de session.
+class SessionManager {
+  final String targetBaseUrl;
+  final String username;
+  final String password;
+  final HttpClient httpClient;
+
+  String? _sessionCookie;
+  Completer<bool>? _loginCompleter;
+  String? _userField;
+  String? _passField;
+
+  SessionManager({
+    required this.targetBaseUrl,
+    required this.username,
+    required this.password,
+  }) : httpClient = HttpClient() {
+    httpClient.badCertificateCallback = (cert, host, port) => true;
+    httpClient.connectionTimeout = const Duration(seconds: 5);
+  }
+
+  String? get sessionCookie => _sessionCookie;
+
+  /// Détecte les noms des champs du formulaire de login depuis le HTML.
+  Future<void> _detectFormFields() async {
+    if (_userField != null) return; // déjà détecté
+    _userField = 'user';
+    _passField = 'pass';
+    try {
+      final uri = Uri.parse(targetBaseUrl).resolve('/login');
+      final req = await httpClient.getUrl(uri);
+      req.headers.set('Accept', 'text/html,*/*');
+      req.followRedirects = false;
+      final resp = await req.close();
+      final html = await resp.transform(utf8.decoder).join();
+
+      final inputs = RegExp(r'<input[^>]*>', caseSensitive: false).allMatches(html);
+      for (final input in inputs) {
+        final tag = input.group(0)!;
+        final nameMatch = RegExp(r"""name\s*=\s*['"](\w+)['"]""").firstMatch(tag);
+        final typeMatch = RegExp(r"""type\s*=\s*['"](\w+)['"]""").firstMatch(tag);
+        if (nameMatch != null) {
+          final name = nameMatch.group(1)!;
+          final type = (typeMatch?.group(1) ?? 'text').toLowerCase();
+          if (type == 'text' || type == 'email') _userField = name;
+          if (type == 'password') _passField = name;
+        }
+      }
+      print('[SESSION] Detected form fields: user=$_userField, pass=$_passField');
+    } catch (e) {
+      print('[SESSION] Form field detection failed: $e');
+    }
+  }
+
+  /// POST /login, extrait le cookie de session.
+  Future<bool> login() async {
+    if (_loginCompleter != null) {
+      return _loginCompleter!.future;
+    }
+
+    _loginCompleter = Completer<bool>();
+
+    try {
+      // Détecter les noms des champs du formulaire
+      await _detectFormFields();
+
+      final uri = Uri.parse(targetBaseUrl).resolve('/login');
+      final request = await httpClient.postUrl(uri);
+      request.headers.set('Content-Type', 'application/x-www-form-urlencoded');
+      request.followRedirects = false;
+
+      final body = '$_userField=${Uri.encodeComponent(username)}&$_passField=${Uri.encodeComponent(password)}';
+      print('[SESSION] POST /login with: $_userField=***, $_passField=***');
+      request.add(utf8.encode(body));
+
+      final response = await request.close();
+
+      // Chercher le cookie sur la réponse du POST
+      var cookies = response.headers['set-cookie'];
+      print('[SESSION] Login POST status=${response.statusCode}, set-cookie=$cookies');
+
+      // Si redirect (303/302) sans cookie → suivre la redirection pour récupérer le cookie
+      if ((cookies == null || cookies.isEmpty) &&
+          response.statusCode >= 300 &&
+          response.statusCode < 400) {
+        final location = response.headers.value('location');
+        print('[SESSION] No cookie on redirect, following → $location');
+        await response.drain();
+        if (location != null) {
+          final redirectUri = uri.resolve(location);
+          final redirectReq = await httpClient.getUrl(redirectUri);
+          redirectReq.followRedirects = false;
+          final redirectResp = await redirectReq.close();
+          cookies = redirectResp.headers['set-cookie'];
+          print('[SESSION] Redirect response status=${redirectResp.statusCode}, set-cookie=$cookies');
+          await redirectResp.drain();
+        }
+      } else {
+        await response.drain();
+      }
+
+      if (cookies != null && cookies.isNotEmpty) {
+        final cookieParts = <String>[];
+        for (final cookieHeader in cookies) {
+          final nameValue = cookieHeader.split(';').first.trim();
+          if (nameValue.isNotEmpty) {
+            cookieParts.add(nameValue);
+          }
+        }
+        if (cookieParts.isNotEmpty) {
+          _sessionCookie = cookieParts.join('; ');
+          print('[SESSION] Login OK, cookie=$_sessionCookie');
+          _loginCompleter!.complete(true);
+          _loginCompleter = null;
+          return true;
+        }
+      }
+
+      print('[SESSION] Login FAILED: no set-cookie header');
+      _loginCompleter!.complete(false);
+      _loginCompleter = null;
+      return false;
+    } catch (e) {
+      _loginCompleter!.complete(false);
+      _loginCompleter = null;
+      return false;
+    }
+  }
+
+  /// Retourne le cookie de session, effectue le login si nécessaire.
+  Future<String?> getSessionCookie() async {
+    if (_sessionCookie == null) {
+      await login();
+    }
+    return _sessionCookie;
+  }
+
+  /// Détecte si une réponse est la page de login (session expirée).
+  bool isLoginPage(int statusCode, String body, String? locationHeader) {
+    // 401 Unauthorized = session expirée ou cookie invalide
+    if (statusCode == 401) {
+      return true;
+    }
+    if (_hasLoginForm(body)) {
+      return true;
+    }
+    if (statusCode >= 300 && statusCode < 400) {
+      final loc = locationHeader ?? '';
+      if (loc.contains('/login')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Invalide la session (force un re-login au prochain appel).
+  void invalidateSession() {
+    _sessionCookie = null;
+  }
+
+  /// Met à jour le cookie de session (ex: l'ESP32 a rafraîchi le cookie).
+  void updateSessionCookie(String newCookie) {
+    _sessionCookie = newCookie;
+  }
+
+  /// GET authentifié avec re-login automatique si session expirée.
+  Future<AuthenticatedResponse> authenticatedGet(String path) async {
+    final cookie = await getSessionCookie();
+    final uri = Uri.parse(targetBaseUrl).resolve(path);
+
+    var request = await httpClient.getUrl(uri);
+    if (cookie != null) {
+      request.headers.set('Cookie', cookie);
+    }
+    request.followRedirects = false;
+    var response = await request.close();
+    var body = await response.transform(utf8.decoder).join();
+    final location = response.headers.value('location');
+
+    if (isLoginPage(response.statusCode, body, location)) {
+      _sessionCookie = null;
+      final success = await login();
+      if (success) {
+        request = await httpClient.getUrl(uri);
+        request.headers.set('Cookie', _sessionCookie!);
+        request.followRedirects = false;
+        response = await request.close();
+        body = await response.transform(utf8.decoder).join();
+      }
+    }
+
+    return AuthenticatedResponse(response.statusCode, body);
+  }
+
+  void close() {
+    httpClient.close();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+30
+version: 1.1.0+32
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
Proxy: auto-detect form-based vs Basic Auth, session cookie management, redirect/login loop handling, fallback to Basic Auth on form login failure. Reuse SessionManager to avoid double login, strip /login from resolved URL.

TV: unified TVDetector singleton, D-pad navigation with focus borders, AppBar hidden in WebView (back button to return), accelerating cursor with edge-scroll and click feedback, TV popup menu for device actions, zoom 60% on TV, autofocus on dialog TextFields, theme focus styles.