### PR TITLE
Fix FCM in release: update google-services.json and add ProGuard rules

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -7,3 +7,18 @@
 
 # Flutter WorkManager plugin
 -keep class be.tramckrijte.workmanager.** { *; }
+
+# Firebase Core
+-keep class com.google.firebase.** { *; }
+-dontwarn com.google.firebase.**
+
+# Firebase Messaging (FCM)
+-keep class com.google.firebase.messaging.** { *; }
+-keep class com.google.android.gms.** { *; }
+-dontwarn com.google.android.gms.**
+
+# Flutter Local Notifications
+-keep class com.dexterous.** { *; }
+
+# Flutter Firebase plugins
+-keep class io.flutter.plugins.firebase.** { *; }


### PR DESCRIPTION
Update google-services.json with Play Store SHA fingerprint. Add ProGuard keep rules for Firebase, GMS, Flutter Local Notifications to prevent R8 from stripping FCM classes in release builds.